### PR TITLE
Fix image not saving issue

### DIFF
--- a/src/hooks/sanitizeHtml.js
+++ b/src/hooks/sanitizeHtml.js
@@ -28,6 +28,7 @@ export default (...fieldNames) => context => {
           ],
           allowedAttributes: {
             iframe: ['src', 'allowfullscreen', 'frameborder'],
+            img: ['src'],
             a: ['target', 'href'],
           },
           allowedClasses: {


### PR DESCRIPTION
* Allows image tags to carry src attribute when sent to client.
See more @ [#301](https://github.com/Giveth/giveth-dapp/pull/301)
