### PR TITLE
[FIX #229] formatting issue when editing

### DIFF
--- a/src/hooks/sanitizeHtml.js
+++ b/src/hooks/sanitizeHtml.js
@@ -25,6 +25,7 @@ export default (...fieldNames) => context => {
             'img',
             'iframe',
             'a',
+            'br',
           ],
           allowedAttributes: {
             iframe: ['src', 'allowfullscreen', 'frameborder'],


### PR DESCRIPTION
fixes https://github.com/Giveth/giveth-dapp/issues/229

Changed the configuration of the hook `sanitizeHtml` to allow `<br>` tags. This fix keeps empty paragraphs `<p><br></p>` which Quill (the editor) needs this in order to make the cursor work inside the empty lines (https://github.com/quilljs/quill/issues/1328#issuecomment-281690977) and it also preserves linebreaks as the user would expect.