### PR TITLE
Donations: Add optional campaignId to model.

### DIFF
--- a/src/models/donations.model.js
+++ b/src/models/donations.model.js
@@ -36,6 +36,7 @@ function Donation(app) {
       delegateId: { type: Schema.Types.Long }, // we can use Long here b/c lp only stores adminId in pledges as uint64
       delegateTypeId: { type: String },
       delegateType: { type: String },
+      campaignId: { type: String },
       status: {
         type: String,
         require: true,


### PR DESCRIPTION
The campaignId can be optionally use to store campaign id when
a donation is made for campaign or a milestone. Then all donations
for a campaign, including milestone donations can be queried
using campaigId field.

Refs: https://github.com/Giveth/giveth-dapp/issues/67