### PR TITLE
Failed tx monitor

### DIFF
--- a/src/blockchain/failedTxMonitor.js
+++ b/src/blockchain/failedTxMonitor.js
@@ -1,4 +1,5 @@
 const LiquidPledgingArtifact = require('giveth-liquidpledging/build/LiquidPledging.json');
+const { toBN } = require('web3-utils');
 const logger = require('winston');
 const LPVaultArtifact = require('giveth-liquidpledging/build/LPVault.json');
 const LPPCappedMilestoneArtifact = require('lpp-capped-milestone/build/LPPCappedMilestone.json');
@@ -30,11 +31,7 @@ function getPending(app, service, query) {
 
 function getPendingDonations(app) {
   const query = {
-    $or: [
-      { status: DonationStatus.PENDING },
-      { pendingAmountRemaining: { $exists: true } },
-      { mined: false },
-    ],
+    $or: [{ status: DonationStatus.PENDING }, { mined: false }],
   };
   return getPending(app, 'donations', query);
 }
@@ -58,6 +55,30 @@ function getPendingMilestones(app) {
   return getPending(app, 'milestones', query);
 }
 
+function createFailedDonationSingleParentMutation(parentDonation, donation) {
+  const amount = toBN(donation.amount);
+  const mutation = {};
+  let { pendingAmountRemaining } = parentDonation;
+  if (!pendingAmountRemaining) return {};
+
+  pendingAmountRemaining = toBN(pendingAmountRemaining);
+
+  if (pendingAmountRemaining.eq(amount)) {
+    mutation.$unset = { pendingAmountRemaining: true };
+  } else if (pendingAmountRemaining.lt(amount)) {
+    logger.error(
+      'Failed donation w/ single parentDonation has amount > parentDonation.pendingAmountRemaining',
+      donation,
+      pendingAmountRemaining.toString(),
+    );
+    mutation.$unset = { pendingAmountRemaining: true };
+  } else {
+    mutation.pendingAmountRemaining = pendingAmountRemaining.sub(amount).toString();
+  }
+
+  return mutation;
+}
+
 /**
  * factory function for generating a failedTxMonitor.
  */
@@ -67,12 +88,86 @@ const failedTxMonitor = (app, eventWatcher) => {
   const decoders = eventDecoders();
   const { requiredConfirmations } = app.get('blockchain');
 
+  async function updateFailedDonationParents(donation) {
+    const donationService = app.service('donations');
+    const parentIds = donation.parentDonations;
+
+    const parentDonations = await donationService.find({
+      paginate: false,
+      query: { _id: { $in: parentIds } },
+    });
+
+    let remaining = toBN(donation.amount);
+
+    if (parentIds.length === 1) {
+      const mutation = createFailedDonationSingleParentMutation(parentDonations[0], donation);
+      donationService.patch(parentDonations[0]._id, mutation);
+      return;
+    }
+
+    // if sum of all parentDonations.amountRemaining w/ pendingAmountRemaining == donation.amount
+    // we can just unset add pendingAmountRemaining on the parents
+    const totalAmountRemaining = parentDonations
+      .filter(d => !!d.pendingAmountRemaining)
+      .reduce((amounts, d) => amounts.add(toBN(d.amountRemaining)), toBN(0));
+
+    if (totalAmountRemaining.eq(remaining)) {
+      donationService.patch(
+        null,
+        { $unset: { pendingAmountRemaining: true } },
+        { query: { _id: { $in: parentIds } } },
+      );
+      return;
+    }
+
+    // TODO: there may be edge cases where this doesn't update correctly and should be further analyzed.
+    // sort any donations w/ pendingAmountRemaining > 0 first
+    parentDonations.sort((a, b) => {
+      const aPending = toBN(a.pendingAmountRemaining);
+      const bPending = toBN(b.pendingAmountRemaining);
+
+      if (aPending.eqn(0) && bPending.eqn(0)) return 0;
+      if (aPending.eqn(0)) return 1;
+      return -1;
+    });
+
+    parentDonations.forEach(async d => {
+      if (remaining.eqn(0)) {
+        logger.warn('too many parent Donations fetched. total is already 0', donation, parentIds);
+        return;
+      }
+
+      // calculate remaining total & donation amountRemaining
+      let pendingAmountRemaining = toBN(d.pendingAmountRemaining);
+      let amountPending = toBN(d.amount).sub(pendingAmountRemaining);
+      if (remaining.gte(amountPending)) {
+        remaining = remaining.sub(amountPending);
+        amountPending = toBN(0);
+      } else {
+        pendingAmountRemaining = pendingAmountRemaining.add(remaining);
+        remaining = toBN(0);
+      }
+
+      if (pendingAmountRemaining.gt(toBN(d.amount))) {
+        throw new Error(
+          `donation.pendingAmountRemaining is < donation.amount: ${JSON.stringify(d)}`,
+        );
+      }
+
+      const mutation = amountPending.eqn(0)
+        ? { $unset: { pendingAmountRemaining: true } }
+        : { pendingAmountRemaining };
+
+      await donationService.patch(d._id, mutation);
+    });
+  }
+
   async function handlePendingDonation(
     currentBlock,
     donation,
     receipt,
     topics,
-    failedDonationMutation,
+    failedDonationMutation = {},
   ) {
     // reset the donation status if the tx has been pending for more then 2 hrs, otherwise ignore
     if (!receipt && donation.updatedAt <= Date.now() - TWO_HOURS) return;
@@ -80,6 +175,9 @@ const failedTxMonitor = (app, eventWatcher) => {
     if (receipt && currentBlock - receipt.blockNumber < requiredConfirmations) return;
 
     if (!receipt || !receipt.status) {
+      if (donation.parentDonations.length > 0) {
+        updateFailedDonationParents(donation);
+      }
       app
         .service('donations')
         .patch(donation._id, failedDonationMutation)
@@ -141,9 +239,7 @@ const failedTxMonitor = (app, eventWatcher) => {
 
     const topics = topicsFromArtifacts([LiquidPledgingArtifact], ['Transfer']);
 
-    handlePendingDonation(currentBlock, donation, receipt, topics, {
-      $unset: { pendingAmountRemaining: true },
-    });
+    handlePendingDonation(currentBlock, donation, receipt, topics);
   }
 
   async function updateDACIfFailed(currentBlock, dac) {

--- a/src/blockchain/pledges.js
+++ b/src/blockchain/pledges.js
@@ -266,7 +266,7 @@ const pledges = (app, liquidPledging) => {
     return donationService.patch(donations[0]._id, mutation);
   }
 
-  async function newDonation(pledgeId, amount, txHash) {
+  async function newDonation(pledgeId, amount, ts, txHash) {
     const pledge = await liquidPledging.getPledge(pledgeId);
     const giver = await getPledgeAdmin(pledge.owner);
 
@@ -280,10 +280,11 @@ const pledges = (app, liquidPledging) => {
       ownerType: giver.type,
       status: DonationStatus.WAITING, // waiting for delegation by owner
       mined: true,
+      createdAt: ts,
       txHash,
     };
 
-    return createDonation(mutation, txHash);
+    return createDonation(mutation, !!txHash);
   }
 
   /**
@@ -464,7 +465,7 @@ const pledges = (app, liquidPledging) => {
       const txHash = event.transactionHash;
       const ts = await getBlockTimestamp(web3, event.blockNumber);
       if (Number(from) === 0) {
-        const [err] = await toWrapper(newDonation(to, amount, txHash));
+        const [err] = await toWrapper(newDonation(to, amount, ts, txHash));
 
         if (err) {
           logger.error('newDonation error ->', err);

--- a/src/blockchain/watcher.js
+++ b/src/blockchain/watcher.js
@@ -348,11 +348,9 @@ const watcher = (app, eventHandler) => {
       query: { $limit: 1, $sort: { createdAt: -1 } },
     });
 
-    console.log(lastDonation);
     if (lastDonation.length > 0) {
       const lastEventTs =
         lastEvent.length > 0 ? await getBlockTimestamp(web3, lastEvent[0].blockNumber) : 0;
-      console.log(lastEventTs);
       if (lastDonation[0].createdAt > lastEventTs) {
         logger.error(
           `It appears that you are attempting to reprocess events, or the events table has 

--- a/src/utils/dappMailer.js
+++ b/src/utils/dappMailer.js
@@ -22,7 +22,7 @@ const sendEmail = (app, data) => {
 
   // add host to subject for development
   if (!app.get('host').includes('beta')) {
-    data.subject = `[${app.get('host')}] - ` + data.subject
+    data.subject = `[${app.get('host')}] - ${data.subject}`;
   }
 
   rp({


### PR DESCRIPTION
I suspect there is an edge case where this fix will not work, but the probability of that happen is extremely low if not 0.

It would involve multiple delegation txs w/ more then 1 parentDonations & a shared parentDonation between the 2 delegation & 1 of the delegation failing. I suspect that feathers will not be synced correctly. We can address that if it ever happens. Worst case right now is we would need to re-sync feathers.

Also includes a fix to set the correct `createdAt` ts for new donations when feathers is re-synced & prevents re-syncing w/o dropping the `donations` table as well as the `events`