### PR TITLE
WBTC and BTC should always be equal

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -96,6 +96,14 @@
       "foreignAddress": "0x8F086f895deBc23473dfe507dd4BF35D6184552c",
       "symbol": "ANT",
       "decimals": 3
+    },
+    {
+      "name": "WBTC",
+      "address": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ac",
+      "foreignAddress": "0x8F086f895deBc23473dfe507dd4BF35D6184552c",
+      "symbol": "WBTC",
+      "rateEqSymbol": "BTC",
+      "decimals": 3
     }
   ],
   "activeTokenWhitelist": [
@@ -103,7 +111,6 @@
       "name": "Home Ganache ETH",
       "address": "0x0",
       "foreignAddress": "0x5a42ca500aB159c51312B764bb25C135026e7a31",
-      "coingeckoid": "eth",
       "symbol": "ETH",
       "decimals": 6
     },
@@ -112,7 +119,14 @@
       "address": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab",
       "foreignAddress": "0x8F086f895deBc23473dfe507dd4BF35D6184552c",
       "symbol": "ANT",
-      "coingeckoid": "ant",
+      "decimals": 3
+    },
+    {
+      "name": "WBTC",
+      "address": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ac",
+      "foreignAddress": "0x8F086f895deBc23473dfe507dd4BF35D6184552c",
+      "symbol": "WBTC",
+      "rateEqSymbol": "BTC",
       "decimals": 3
     }
   ],

--- a/config/default.json
+++ b/config/default.json
@@ -96,14 +96,6 @@
       "foreignAddress": "0x8F086f895deBc23473dfe507dd4BF35D6184552c",
       "symbol": "ANT",
       "decimals": 3
-    },
-    {
-      "name": "WBTC",
-      "address": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ac",
-      "foreignAddress": "0x8F086f895deBc23473dfe507dd4BF35D6184552c",
-      "symbol": "WBTC",
-      "rateEqSymbol": "BTC",
-      "decimals": 3
     }
   ],
   "activeTokenWhitelist": [
@@ -111,6 +103,7 @@
       "name": "Home Ganache ETH",
       "address": "0x0",
       "foreignAddress": "0x5a42ca500aB159c51312B764bb25C135026e7a31",
+      "coingeckoid": "eth",
       "symbol": "ETH",
       "decimals": 6
     },
@@ -119,14 +112,7 @@
       "address": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab",
       "foreignAddress": "0x8F086f895deBc23473dfe507dd4BF35D6184552c",
       "symbol": "ANT",
-      "decimals": 3
-    },
-    {
-      "name": "WBTC",
-      "address": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ac",
-      "foreignAddress": "0x8F086f895deBc23473dfe507dd4BF35D6184552c",
-      "symbol": "WBTC",
-      "rateEqSymbol": "BTC",
+      "coingeckoid": "ant",
       "decimals": 3
     }
   ],

--- a/src/services/conversionRates/getConversionRatesService.js
+++ b/src/services/conversionRates/getConversionRatesService.js
@@ -1,5 +1,6 @@
 const rp = require('request-promise');
 const logger = require('winston');
+const errors = require('@feathersjs/errors');
 
 const MINUTE = 1000 * 60;
 
@@ -106,11 +107,11 @@ const _getRatesCoinGecko = async (
  * @param {Number} timestamp   Timestamp for which the value should be retrieved
  * @param {Array}  ratestToGet Rates that are missing in the DB and should be retrieved
  * @param {Array}  stableCoins coins whose value equal one usd
- * @param {String}  rateEqSymbol This field use for tokens like WBTC that has equivalent value of another currency like BTC
  *
  * @return {Object} Rates object in format { EUR: 241, USD: 123 }
  */
-const _getRatesCryptocompare = async (timestamp, ratesToGet, symbol, stableCoins, rateEqSymbol) => {
+const _getRatesCryptocompare = async (timestamp, ratesToGet, symbol, stableCoins) => {
+  logger.debug("_getRatesCryptocompare ",{timestamp, ratesToGet, symbol, stableCoins})
   logger.debug(`Fetching coversion rates from crypto compare for: ${ratesToGet}`);
   const timestampMS = Math.round(timestamp / 1000);
 
@@ -118,11 +119,11 @@ const _getRatesCryptocompare = async (timestamp, ratesToGet, symbol, stableCoins
   //TODO I think this can be removed because in else statement this field will set
   rates[symbol] = 1;
 
-  const requestSymbol = stableCoins.includes(symbol) ? 'USD' : rateEqSymbol ||symbol;
+  const requestSymbol = stableCoins.includes(symbol) ? 'USD' : symbol;
   // Fetch the conversion rate
   const promises = ratesToGet.map(async r => {
     const rateSymbol = stableCoins.includes(r) ? 'USD' : r;
-    if (rateSymbol !== requestSymbol && rateSymbol !== symbol) {
+    if (rateSymbol !== requestSymbol) {
       const resp = JSON.parse(
         await rp(
           `https://min-api.cryptocompare.com/data/dayAvg?fsym=${requestSymbol}&tsym=${rateSymbol}&toTs=${timestampMS}&extraParams=giveth`,
@@ -267,7 +268,7 @@ const _saveToDB = (app, timestamp, rates, symbol, _id = undefined) => {
  *
  * @return {Promise} Promise that resolves to object {timestamp, rates: { EUR: 100, USD: 90 } }
  */
-const getConversionRates = async (app, requestedDate, requestedSymbol = 'ETH') => {
+const getConversionRates = async (app, requestedDate, symbol = 'ETH') => {
   // Get yesterday date from today respecting UTC
   const yesterday = new Date(new Date().setUTCDate(new Date().getUTCDate() - 1));
   const yesterdayUTC = yesterday.setUTCHours(0, 0, 0, 0);
@@ -284,17 +285,13 @@ const getConversionRates = async (app, requestedDate, requestedSymbol = 'ETH') =
   const stableCoins = app.get('stableCoins') || [];
 
   const tokens =app.get('tokenWhitelist');
-  let coingeckoId = '';
-  let rateEqSymbol = undefined;
-  tokens.forEach(token => {
-    if (token.symbol === requestedSymbol) {
-      //This field needed for PAN currency
-      coingeckoId = token.coingeckoid;
-
-      rateEqSymbol = token.rateEqSymbol
-    }
-  });
-
+  const token = tokens.find(token => token.symbol === symbol);
+  if (!token) {
+    throw new errors.BadRequest(`Token with symbol ${symbol} is not in whitelist`)
+  }
+  //This field needed for PAN currency
+  const coingeckoId = token.coingeckoid;
+  const requestedSymbol = token.rateEqSymbol || symbol;
   logger.debug(`request eth conversion for timestamp ${timestamp}`);
 
   // Check if we already have this exchange rate for this timestamp, if not we save it
@@ -321,8 +318,7 @@ const getConversionRates = async (app, requestedDate, requestedSymbol = 'ETH') =
         timestamp,
         unknownRates,
         requestedSymbol,
-        stableCoins,
-        rateEqSymbol
+        stableCoins
       );
     }
 

--- a/src/services/conversionRates/getConversionRatesService.js
+++ b/src/services/conversionRates/getConversionRatesService.js
@@ -111,12 +111,10 @@ const _getRatesCoinGecko = async (
  * @return {Object} Rates object in format { EUR: 241, USD: 123 }
  */
 const _getRatesCryptocompare = async (timestamp, ratesToGet, symbol, stableCoins) => {
-  logger.debug("_getRatesCryptocompare ",{timestamp, ratesToGet, symbol, stableCoins})
   logger.debug(`Fetching coversion rates from crypto compare for: ${ratesToGet}`);
   const timestampMS = Math.round(timestamp / 1000);
 
   const rates = {};
-  //TODO I think this can be removed because in else statement this field will set
   rates[symbol] = 1;
 
   const requestSymbol = stableCoins.includes(symbol) ? 'USD' : symbol;
@@ -284,12 +282,12 @@ const getConversionRates = async (app, requestedDate, symbol = 'ETH') => {
   const fiat = app.get('fiatWhitelist');
   const stableCoins = app.get('stableCoins') || [];
 
-  const tokens =app.get('tokenWhitelist');
-  const token = tokens.find(token => token.symbol === symbol);
+  const tokens = app.get('tokenWhitelist');
+  const token = tokens.find(item => item.symbol === symbol);
   if (!token) {
-    throw new errors.BadRequest(`Token with symbol ${symbol} is not in whitelist`)
+    throw new errors.BadRequest(`Token with symbol ${symbol} is not in whitelist`);
   }
-  //This field needed for PAN currency
+  // This field needed for PAN currency
   const coingeckoId = token.coingeckoid;
   const requestedSymbol = token.rateEqSymbol || symbol;
   logger.debug(`request eth conversion for timestamp ${timestamp}`);
@@ -318,7 +316,7 @@ const getConversionRates = async (app, requestedDate, symbol = 'ETH') => {
         timestamp,
         unknownRates,
         requestedSymbol,
-        stableCoins
+        stableCoins,
       );
     }
 

--- a/src/services/conversionRates/getConversionRatesService.js
+++ b/src/services/conversionRates/getConversionRatesService.js
@@ -106,21 +106,23 @@ const _getRatesCoinGecko = async (
  * @param {Number} timestamp   Timestamp for which the value should be retrieved
  * @param {Array}  ratestToGet Rates that are missing in the DB and should be retrieved
  * @param {Array}  stableCoins coins whose value equal one usd
+ * @param {String}  rateEqSymbol This field use for tokens like WBTC that has equivalent value of another currency like BTC
  *
  * @return {Object} Rates object in format { EUR: 241, USD: 123 }
  */
-const _getRatesCryptocompare = async (timestamp, ratesToGet, symbol, stableCoins) => {
+const _getRatesCryptocompare = async (timestamp, ratesToGet, symbol, stableCoins, rateEqSymbol) => {
   logger.debug(`Fetching coversion rates from crypto compare for: ${ratesToGet}`);
   const timestampMS = Math.round(timestamp / 1000);
 
   const rates = {};
+  //TODO I think this can be removed because in else statement this field will set
   rates[symbol] = 1;
 
-  const requestSymbol = stableCoins.includes(symbol) ? 'USD' : symbol;
+  const requestSymbol = stableCoins.includes(symbol) ? 'USD' : rateEqSymbol ||symbol;
   // Fetch the conversion rate
   const promises = ratesToGet.map(async r => {
     const rateSymbol = stableCoins.includes(r) ? 'USD' : r;
-    if (rateSymbol !== requestSymbol) {
+    if (rateSymbol !== requestSymbol && rateSymbol !== symbol) {
       const resp = JSON.parse(
         await rp(
           `https://min-api.cryptocompare.com/data/dayAvg?fsym=${requestSymbol}&tsym=${rateSymbol}&toTs=${timestampMS}&extraParams=giveth`,
@@ -281,12 +283,15 @@ const getConversionRates = async (app, requestedDate, requestedSymbol = 'ETH') =
   const fiat = app.get('fiatWhitelist');
   const stableCoins = app.get('stableCoins') || [];
 
-  const tokens = app.get('activeTokenWhitelist');
+  const tokens =app.get('tokenWhitelist');
   let coingeckoId = '';
-
+  let rateEqSymbol = undefined;
   tokens.forEach(token => {
     if (token.symbol === requestedSymbol) {
+      //This field needed for PAN currency
       coingeckoId = token.coingeckoid;
+
+      rateEqSymbol = token.rateEqSymbol
     }
   });
 
@@ -317,6 +322,7 @@ const getConversionRates = async (app, requestedDate, requestedSymbol = 'ETH') =
         unknownRates,
         requestedSymbol,
         stableCoins,
+        rateEqSymbol
       );
     }
 


### PR DESCRIPTION
Now every token can has the value equal another token just by adding  equivalentSymbol property to a token in config
example: 
```
  {
      "name": "WBTC",
      "address": "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ac",
      "foreignAddress": "0x8F086f895deBc23473dfe507dd4BF35D6184552c",
      "symbol": "WBTC",
      "equivalentSymbol": "BTC",
      "decimals": 3
    }
```

fix this issue:
https://github.com/Giveth/giveth-dapp/issues/1506
