### PR TITLE
Milestone paid email shows incorrect value of amount

### DIFF
--- a/src/utils/dappMailer.js
+++ b/src/utils/dappMailer.js
@@ -385,7 +385,7 @@ module.exports = {
           data.milestoneTitle
         }</em>:</p>
         <p></p>
-        ${data.donationCounters.map(c => `<p>${c.currentBalance / 10 ** 18} ${c.symbol}</p>`)}
+        ${data.donationCounters.map(c => `<p>${c.totalDonated / 10 ** 18} ${c.symbol}</p>`)}
         <p></p>
         <p>You can expect to see these payment(s) to arrive in your wallet <em>${
           data.address


### PR DESCRIPTION
In previous code the donated amount read from `currentBalance` that I saw it was `'0'` for all `milestones.donationCounters` and I think the correct field is `totalDonated ` as in the https://github.com/Giveth/giveth-dapp show that field and beside that check this milestone :  https://beta.giveth.io/campaigns/5b39d45e14cec916d00dab20/milestones/5b3a5b0bdf629170d472b3cf
That you see the `totalDonated` value is:
```
 "donationCounters": [
        {
            "_id": "5cdc2226a16c6c16214d29ef",
            "name": "ETH",
            "address": "0x0",
            "decimals": "6",
            "symbol": "ETH",
            "totalDonated": "221720630000000000",
            "currentBalance": "0",
            "donationCount": 1
        }
    ],

```

Fix #246