### PR TITLE
Email title for milestone cancel and pay actions

### DIFF
--- a/src/utils/dappMailer.js
+++ b/src/utils/dappMailer.js
@@ -327,7 +327,7 @@ module.exports = {
       subject: 'Giveth - Milestone canceled :-(',
       type: 'milestone-canceled',
       secretIntro: `Your Milestone ${data.milestoneTitle} has been canceled.`,
-      title: 'Milestone canceled.',
+      title: 'Milestone Canceled',
       image: 'Giveth-milestone-canceled-banner-email.png',
       text: `
         <p><span style="line-height: 33px; font-size: 22px;">Hi ${data.user}</span></p>
@@ -377,7 +377,7 @@ module.exports = {
       subject: 'Giveth - Milestone paid',
       type: 'milestone-paid',
       secretIntro: `Your Milestone ${data.milestoneTitle} has been paid.`,
-      title: 'Milestone paid.',
+      title: 'Milestone Paid',
       image: 'Giveth-milestone-review-approved-banner-email.png',
       text: `
         <p><span style="line-height: 33px; font-size: 22px;">Hi ${data.user}</span></p>


### PR DESCRIPTION
As amin wanted `Milestone paid.` changed to  `Milestone Paid` and  `Milestone canceled.` to `Milestone Canceled`

fix #247