### PR TITLE
F 291 configure circleci to run mongo server for test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
+      - image: circleci/mongo:4.4.2
 
     working_directory: ~/repo
 
@@ -27,6 +27,7 @@ jobs:
       #     - v1-dependencies-
 
       - run: npm install
+      - run: npm run test
 
       # - save_cache:
       #     paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ jobs:
       #     - v1-dependencies-
 
       - run: npm install
-      - run: npm run test
 
       # - save_cache:
       #     paths:
@@ -38,6 +37,16 @@ jobs:
       # - run: yarn test
       # run linter
       - run: npm run eslint
+      - run: mkdir reports
+      - run:
+          command: npm run test:circleci
+          environment:
+            MOCHA_FILE: reports/mocha/test-results.xml
+          when: always
+      - store_test_results:
+          path: reports
+      - store_artifacts:
+          path: ./reports/mocha/test-results.xml
       - deploy:
           name: Production Deploy
           command: |

--- a/config/test.json
+++ b/config/test.json
@@ -1,6 +1,6 @@
 {
   "port": 3040,
-  "mongodb": "mongodb://localhost:28016/giveth",
+  "mongodb": "mongodb://localhost:27017/giveth-test",
   "givethFathersBaseUrl": "http://localhost:3040",
   "useProjectOwnerWhitelist": false,
   "tokenWhitelist": [

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "scripts": {
     "test-old": "npm run eslint && npm run mocha",
-    "test": "LOG_LEVEL=info  NODE_ENV=test mocha -t 10000  test/pre-tests-script.js  src/**/*.test.js src/**/**/*.test.js",
-    "test:circleci": "LOG_LEVEL=info NODE_ENV=test mocha -t 10000 --reporter mocha-junit-reporter  test/pre-tests-script.js  src/**/*.test.js  src/**/**/*.test.js",
+    "test": "LOG_LEVEL=info  NODE_ENV=test mocha -t 10000  test/pre-tests-script.js  src/**/*.test.js  src/**/**/*.test.js  test/post-tests-script.js",
+    "test:circleci": "LOG_LEVEL=info NODE_ENV=test mocha -t 10000 --reporter mocha-junit-reporter  test/pre-tests-script.js  src/**/*.test.js  src/**/**/*.test.js test/post-tests-script.js",
     "test:coverage": "nyc -e '.ts' --r html -r lcov -r text npm run test",
     "eslint": "eslint src/. test/.",
     "eslint:fix": "eslint src/. test/. --fix",

--- a/test/post-tests-script.js
+++ b/test/post-tests-script.js
@@ -1,0 +1,7 @@
+const mongoose = require('mongoose');
+const config = require('config');
+
+after(() => {
+  console.log('dropping database', config.get('mongodb'));
+  mongoose.connection.db.dropDatabase();
+});

--- a/test/pre-tests-script.js
+++ b/test/pre-tests-script.js
@@ -1,15 +1,4 @@
-// TODO should uncomment MongoMemoryServer stuffs if we want to run tests
-
-// const { MongoMemoryServer } = require('mongodb-memory-server');
 const { seedData } = require('./testUtility');
-
-// const mongoServer = new MongoMemoryServer({
-//   instance: {
-//     port: 28016, // by default choose any free port
-//     dbName: 'giveth', // by default generate random dbName
-//   },
-//   // autoStart:true
-// });
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
fix #291 

Now instead of using `mongodb-memory-server` we use a mongo docker image for tests (in local we use localhost:27017/giveth-test) and after the tests completed we drop the db.