### PR TITLE
Convert tokens to stableCoin if rateEqSymbol of coin is stable

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -123,11 +123,6 @@
     "MXN",
     "THB"
   ],
-  "stableCoins": [
-    "DAI",
-    "SAI",
-    "USDC"
-  ],
   "nativeCurrencyWhitelist": [
     {
       "symbol": "USD",

--- a/config/test.json
+++ b/config/test.json
@@ -60,6 +60,13 @@
       "symbol": "ANT",
       "coingeckoId": "aragon",
       "decimals": "3"
+    },
+    { "name": "MiniMe Test Token",
+      "address": "0xE690E380740a682E2b8CEAEa33584Ea2cb59849E",
+      "foreignAddress": "0xe1DA0672bDBdBc469E82cCACCe9e4c7C79dAF6cf",
+      "symbol": "XDAI",
+      "rateEqSymbol": "DAI",
+      "decimals": 3
     }
   ],
   "activeTokenWhitelist": [

--- a/config/test.json
+++ b/config/test.json
@@ -25,6 +25,7 @@
       "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
       "foreignAddress": "0x05A075B296995AdCaEC7c1dE0E52271a4Cf6DEb8",
       "symbol": "DAI",
+      "rateEqSymbol": "USD",
       "coingeckoId": "dai",
       "decimals": 3
     },
@@ -65,7 +66,7 @@
       "address": "0xE690E380740a682E2b8CEAEa33584Ea2cb59849E",
       "foreignAddress": "0xe1DA0672bDBdBc469E82cCACCe9e4c7C79dAF6cf",
       "symbol": "XDAI",
-      "rateEqSymbol": "DAI",
+      "rateEqSymbol": "USD",
       "decimals": 3
     }
   ],

--- a/src/services/conversionRates/getConversionRatesService.js
+++ b/src/services/conversionRates/getConversionRatesService.js
@@ -308,13 +308,19 @@ const getHourlyCryptoConversion = async (app, ts, fromSymbol = 'ETH', toSymbol =
 
   // Return 1 for stable coins
   const stableCoins = app.get('stableCoins') || [];
-  const normalizedFromSymbol = stableCoins.includes(fromSymbol) ? 'USD' : fromSymbol;
-  const normalizedToSymbol = stableCoins.includes(toSymbol) ? 'USD' : toSymbol;
+  let fromToken = getTokenBySymbol(app, fromSymbol);
+  let toToken = getTokenBySymbol(app, toSymbol);
+  const isFromTokenStableCoin =
+    stableCoins.includes(fromToken.rateEqSymbol) || stableCoins.includes(fromToken.symbol);
+  const isToTokenStableCoin =
+    stableCoins.includes(toToken.rateEqSymbol) || stableCoins.includes(toToken.symbol);
+  const normalizedFromSymbol = isFromTokenStableCoin ? 'USD' : fromSymbol;
+  const normalizedToSymbol = isToTokenStableCoin ? 'USD' : toSymbol;
 
   if (normalizedFromSymbol === normalizedToSymbol) return { timestamp: requestTs, rate: 1 };
 
-  const fromToken = getTokenBySymbol(app, normalizedFromSymbol);
-  const toToken = getTokenBySymbol(app, normalizedToSymbol);
+  fromToken = getTokenBySymbol(app, normalizedFromSymbol);
+  toToken = getTokenBySymbol(app, normalizedToSymbol);
 
   // Check if we already have this exchange rate for this timestamp, if not we save it
   const dbRates = await _getRatesDb(app, requestTs, fromToken.symbol);

--- a/src/services/conversionRates/getConversionRatesService.js
+++ b/src/services/conversionRates/getConversionRatesService.js
@@ -1,5 +1,6 @@
 const rp = require('request-promise');
 const logger = require('winston');
+const { getTokenBySymbol } = require('../../utils/tokenHelper');
 const { fetchCoingecko } = require('./coingecko');
 
 const MINUTE = 1000 * 60;
@@ -35,24 +36,17 @@ const _getRatesDb = async (app, timestamp, symbol = 'ETH') => {
  * @param {Array}  timestampMS Timestamp requested for the rate
  * @param {Array}  coingeckoId the unique coingecko id needed for the token that the api needs
  * @param {Array}  ratestToGet Rates that are missing in the DB and should be retrieved
- * @param {Array}  stableCoins coins whose value equal one usd
  *
  * @return {Object} Rates object in format { 0.241 }
  */
-const _getRatesCoinGecko = async (
-  requestedSymbol,
-  timestampMS,
-  coingeckoId,
-  ratesToGet,
-  stableCoins,
-) => {
+const _getRatesCoinGecko = async (requestedSymbol, timestampMS, coingeckoId, ratesToGet) => {
   const rates = {};
   rates[requestedSymbol] = 1;
 
   const promises = ratesToGet.map(async r => {
-    const rateSymbolInner = stableCoins.includes(r) ? 'USD' : r;
-    if (rateSymbolInner !== requestedSymbol) {
-      rates[r] = await fetchCoingecko(timestampMS, coingeckoId, rateSymbolInner);
+    const symbol = getTokenBySymbol(requestedSymbol).rateEqSymbol || requestedSymbol;
+    if (symbol !== requestedSymbol) {
+      rates[r] = await fetchCoingecko(timestampMS, coingeckoId, symbol);
     } else {
       rates[r] = 1;
     }
@@ -74,21 +68,20 @@ const _getRatesCoinGecko = async (
  *
  * @param {Number} timestamp   Timestamp for which the value should be retrieved
  * @param {Array}  ratestToGet Rates that are missing in the DB and should be retrieved
- * @param {Array}  stableCoins coins whose value equal one usd
  *
  * @return {Object} Rates object in format { EUR: 241, USD: 123 }
  */
-const _getRatesCryptocompare = async (timestamp, ratesToGet, symbol, stableCoins) => {
+const _getRatesCryptocompare = async (timestamp, ratesToGet, symbol) => {
   logger.debug(`Fetching coversion rates from crypto compare for: ${ratesToGet}`);
   const timestampMS = Math.round(timestamp / 1000);
 
   const rates = {};
   rates[symbol] = 1;
 
-  const requestSymbol = stableCoins.includes(symbol) ? 'USD' : symbol;
+  const requestSymbol = getTokenBySymbol(symbol).rateEqSymbol || symbol;
   // Fetch the conversion rate
   const promises = ratesToGet.map(async r => {
-    const rateSymbol = stableCoins.includes(r) ? 'USD' : r;
+    const rateSymbol = getTokenBySymbol(r).rateEqSymbol || r;
     if (rateSymbol !== requestSymbol) {
       const resp = JSON.parse(
         await rp(
@@ -210,19 +203,6 @@ const _saveToDB = (app, timestamp, rates, symbol, _id = undefined) => {
   });
 };
 
-let symbolToToken;
-const getTokenBySymbol = (app, symbol) => {
-  if (!symbolToToken) {
-    symbolToToken = {};
-    const tokens = app.get('tokenWhitelist');
-    tokens.forEach(token => {
-      symbolToToken[token.symbol] = token;
-    });
-  }
-
-  return symbolToToken[symbol] || { symbol };
-};
-
 /**
  * Fetching eth conversion based on daily average from cryptocompare
  * Saves the conversion rates in the backend if we don't have it stored yet.timestamp
@@ -247,9 +227,8 @@ const getConversionRates = async (app, requestedDate, symbol = 'ETH') => {
   const timestamp = reqDateUTC < yesterdayUTC ? reqDateUTC : yesterdayUTC;
 
   const fiat = app.get('fiatWhitelist');
-  const stableCoins = app.get('stableCoins') || [];
 
-  const token = getTokenBySymbol(app, symbol);
+  const token = getTokenBySymbol(symbol);
 
   // This field needed for PAN currency
   const { coingeckoId } = token;
@@ -268,20 +247,9 @@ const getConversionRates = async (app, requestedDate, symbol = 'ETH') => {
     // Some rates have not been obtained yet, get them from cryptocompare
     let newRates = [];
     if (requestedSymbol === 'PAN') {
-      newRates = await _getRatesCoinGecko(
-        requestedSymbol,
-        timestamp,
-        coingeckoId,
-        unknownRates,
-        stableCoins,
-      );
+      newRates = await _getRatesCoinGecko(requestedSymbol, timestamp, coingeckoId, unknownRates);
     } else {
-      newRates = await _getRatesCryptocompare(
-        timestamp,
-        unknownRates,
-        requestedSymbol,
-        stableCoins,
-      );
+      newRates = await _getRatesCryptocompare(timestamp, unknownRates, requestedSymbol);
     }
 
     if (newRates === undefined || newRates === []) {
@@ -307,20 +275,16 @@ const getHourlyCryptoConversion = async (app, ts, fromSymbol = 'ETH', toSymbol =
   const requestTs = ts ? new Date(ts).setUTCMinutes(0, 0, 0) : lastHourUTC;
 
   // Return 1 for stable coins
-  const stableCoins = app.get('stableCoins') || [];
-  let fromToken = getTokenBySymbol(app, fromSymbol);
-  let toToken = getTokenBySymbol(app, toSymbol);
-  const isFromTokenStableCoin =
-    stableCoins.includes(fromToken.rateEqSymbol) || stableCoins.includes(fromToken.symbol);
-  const isToTokenStableCoin =
-    stableCoins.includes(toToken.rateEqSymbol) || stableCoins.includes(toToken.symbol);
-  const normalizedFromSymbol = isFromTokenStableCoin ? 'USD' : fromSymbol;
-  const normalizedToSymbol = isToTokenStableCoin ? 'USD' : toSymbol;
+  let fromToken = getTokenBySymbol(fromSymbol);
+  let toToken = getTokenBySymbol(toSymbol);
+
+  const normalizedFromSymbol = fromToken.rateEqSymbol || fromSymbol;
+  const normalizedToSymbol = toToken.rateEqSymbol || toSymbol;
 
   if (normalizedFromSymbol === normalizedToSymbol) return { timestamp: requestTs, rate: 1 };
 
-  fromToken = getTokenBySymbol(app, normalizedFromSymbol);
-  toToken = getTokenBySymbol(app, normalizedToSymbol);
+  fromToken = getTokenBySymbol(normalizedFromSymbol);
+  toToken = getTokenBySymbol(normalizedToSymbol);
 
   // Check if we already have this exchange rate for this timestamp, if not we save it
   const dbRates = await _getRatesDb(app, requestTs, fromToken.symbol);

--- a/src/services/conversionRates/getConversionRatesService.test.js
+++ b/src/services/conversionRates/getConversionRatesService.test.js
@@ -9,23 +9,29 @@ const { getFeatherAppInstance } = require('../../app');
 const app = getFeatherAppInstance();
 
 function getHourlyCryptoConversionTestCases() {
-  it('Stable coin to USD', async () => {
+  it('DAI to USD', async () => {
     const now = new Date();
     const result = await getHourlyCryptoConversion(app, now.getTime(), 'DAI', 'USD');
     assert.isOk(result);
     assert.equal(result.rate, 1, 'Stable coin rate should equal USD');
   });
 
-  it('XDAI is not stableCoin but rateEqSymbol of XDAI is a stableCoin', async () => {
+  it('XDAI to USD', async () => {
     const now = new Date();
     const result = await getHourlyCryptoConversion(app, now.getTime(), 'XDAI', 'USD');
     assert.isOk(result);
     assert.equal(result.rate, 1, 'XDAI coin rate should equal USD');
   });
 
-  it('USD to Stable coin', async () => {
+  it('USD to DAI', async () => {
     const now = new Date();
     const result = await getHourlyCryptoConversion(app, now.getTime(), 'USD', 'DAI');
+    assert.isOk(result);
+    assert.equal(result.rate, 1, 'USD rate should equal Stable coin');
+  });
+  it('XDAI to DAI, both coins have same rateEqSymbol', async () => {
+    const now = new Date();
+    const result = await getHourlyCryptoConversion(app, now.getTime(), 'XDAI', 'DAI');
     assert.isOk(result);
     assert.equal(result.rate, 1, 'USD rate should equal Stable coin');
   });

--- a/src/services/conversionRates/getConversionRatesService.test.js
+++ b/src/services/conversionRates/getConversionRatesService.test.js
@@ -16,6 +16,13 @@ function getHourlyCryptoConversionTestCases() {
     assert.equal(result.rate, 1, 'Stable coin rate should equal USD');
   });
 
+  it('XDAI is not stableCoin but rateEqSymbol of XDAI is a stableCoin', async () => {
+    const now = new Date();
+    const result = await getHourlyCryptoConversion(app, now.getTime(), 'XDAI', 'USD');
+    assert.isOk(result);
+    assert.equal(result.rate, 1, 'XDAI coin rate should equal USD');
+  });
+
   it('USD to Stable coin', async () => {
     const now = new Date();
     const result = await getHourlyCryptoConversion(app, now.getTime(), 'USD', 'DAI');

--- a/src/utils/tokenHelper.js
+++ b/src/utils/tokenHelper.js
@@ -25,7 +25,7 @@ function getTokenBySymbol(symbol) {
     });
     tokensByAddress[ANY_TOKEN.symbol] = ANY_TOKEN;
   }
-  return tokensBySymbols[symbol];
+  return tokensBySymbols[symbol] || { symbol };
 }
 
 module.exports = {

--- a/src/utils/tokenHelper.test.js
+++ b/src/utils/tokenHelper.test.js
@@ -11,8 +11,10 @@ function getTokenBySymbolTestCases() {
     expect(token).to.be.deep.equal(ethToken);
   });
   it('should return undefined for invalid token symbol', () => {
-    const token = getTokenBySymbol('InvalidTokenSymbol');
-    assert.isNotOk(token);
+    const invalidSymbol = 'InvalidTokenSymbol';
+    const token = getTokenBySymbol(invalidSymbol);
+    assert.isOk(token);
+    assert.equal(token.symbol, invalidSymbol);
   });
 }
 


### PR DESCRIPTION
Fix #318

I think the problem of #318  was because this:
* `DAI` is a stable coin
* `XDAI` is not a stable coin, but `rateEqSymbol` of `XDAI` token  is `DAI`
* In conversionRate we were checking if token is a stable coin we return exactly 1, but the `XDAI` is not stable itself

I fixed this issue by checking if rateEqSymbol token of a token is stable coin we do same behaviour of a stable coin