### PR TITLE
Fix web3helper to not stuck when tx.blockNumber is null

### DIFF
--- a/src/blockchain/lib/eventHandler.js
+++ b/src/blockchain/lib/eventHandler.js
@@ -77,7 +77,14 @@ const eventHandler = app => {
       return new Promise((resolve, reject) => {
         const fn = async () => {
           try {
-            logger.info('Handling Event: ', event);
+            logger.info('Handling Event: ', {
+              event: event.event,
+              transactionHash: event.transactionHash,
+              status: event.status,
+              transactionIndex: event.transactionIndex,
+              logIndex: event.logIndex,
+              _id: event._id,
+            });
             await handler(event);
             resolve();
           } catch (err) {

--- a/src/blockchain/lib/web3Helpers.js
+++ b/src/blockchain/lib/web3Helpers.js
@@ -161,6 +161,9 @@ const txListeners = {};
  * @param {boolean} isHome get transaction of home network
  */
 const getTransaction = async (app, hash, isHome = false) => {
+  if (!hash) {
+    throw new errors.NotFound(`Hash value cannot be undefined`);
+  }
   const Transaction = app.get('transactionsModel');
   const query = { hash, isHome };
   const result = await Transaction.find(query).exec();

--- a/src/blockchain/lib/web3Helpers.js
+++ b/src/blockchain/lib/web3Helpers.js
@@ -180,7 +180,9 @@ const getTransaction = async (app, hash, isHome = false) => {
 
   const web3 = isHome ? app.getHomeWeb3() : app.getWeb3();
   const tx = await web3.eth.getTransaction(hash);
-  if (!tx) {
+  if (!tx || !tx.blockNumber) {
+    // sometimes tx is not null but the tx.blockNumber is null
+    delete txListeners[hash];
     throw new errors.NotFound(`Not tx found for ${hash}`);
   }
   const { from, blockNumber } = tx;

--- a/src/blockchain/pledges.js
+++ b/src/blockchain/pledges.js
@@ -660,7 +660,7 @@ const pledges = (app, liquidPledging) => {
 
       const { from, to, amount } = event.returnValues;
       const txHash = event.transactionHash;
-      const { timestamp } = await getTransaction(web3, event.transactionHash);
+      const { timestamp } = await getTransaction(app, event.transactionHash);
       if (Number(from) === 0) {
         const [err] = await toWrapper(newDonation(to, amount, timestamp, txHash));
 

--- a/src/blockchain/pledges.js
+++ b/src/blockchain/pledges.js
@@ -4,7 +4,7 @@ const logger = require('winston');
 const { toBN } = require('web3-utils');
 const eventDecodersFromArtifact = require('./lib/eventDecodersFromArtifact');
 const topicsFromArtifacts = require('./lib/topicsFromArtifacts');
-const { getBlockTimestamp, executeRequestsAsBatch, ANY_TOKEN } = require('./lib/web3Helpers');
+const { getTransaction, executeRequestsAsBatch, ANY_TOKEN } = require('./lib/web3Helpers');
 const { CampaignStatus } = require('../models/campaigns.model');
 const { DonationStatus } = require('../models/donations.model');
 const { MilestoneStatus, MilestoneTypes } = require('../models/milestones.model');
@@ -660,15 +660,15 @@ const pledges = (app, liquidPledging) => {
 
       const { from, to, amount } = event.returnValues;
       const txHash = event.transactionHash;
-      const ts = await getBlockTimestamp(web3, event.blockNumber);
+      const { timestamp } = await getTransaction(web3, event.transactionHash);
       if (Number(from) === 0) {
-        const [err] = await toWrapper(newDonation(to, amount, ts, txHash));
+        const [err] = await toWrapper(newDonation(to, amount, timestamp, txHash));
 
         if (err) {
           logger.error('newDonation error ->', err);
         }
       } else {
-        await transfer(from, to, amount, ts, txHash);
+        await transfer(from, to, amount, timestamp, txHash);
       }
     },
   };

--- a/src/blockchain/pledges.test.js
+++ b/src/blockchain/pledges.test.js
@@ -26,7 +26,7 @@ function transferTestCases() {
     const badFunc = async () => {
       await pledges.transfer(event);
     };
-    await assertThrowsAsync(badFunc, 'connection not open');
+    await assertThrowsAsync(badFunc, 'Hash value cannot be undefined');
   });
 }
 


### PR DESCRIPTION
Fix #336

The problem happens because sometime the transaction is not null but the `blockNumber` is  null so we get error that when we wanted to call 

`const { timestamp } = await web3.eth.getBlock(blockNumber);`
and the error message was not clear and so hard to understand.

and there is important to do `   delete txListeners[hash];`  when transaction not found or it's corrupted.
(after deploying this branch on develop my donations became commited  instead of remaining Pending

