### PR TITLE
Fix get conversionRates for PAN coin

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   },
   "scripts": {
     "test-old": "npm run eslint && npm run mocha",
-    "test": "LOG_LEVEL=info  NODE_ENV=test mocha -t 10000  test/pre-tests-script.js  src/**/*.test.js  src/**/**/*.test.js  test/post-tests-script.js",
-    "test:conversionRate": "LOG_LEVEL=info  NODE_ENV=test mocha -t 10000  test/pre-tests-script.js  src/services/conversionRates/*.test.js  test/post-tests-script.js",
-    "test:circleci": "LOG_LEVEL=info NODE_ENV=test mocha -t 10000 --reporter mocha-junit-reporter  test/pre-tests-script.js  src/**/*.test.js  src/**/**/*.test.js test/post-tests-script.js",
+    "test": "LOG_LEVEL=info  NODE_ENV=test mocha -t 15000  test/pre-tests-script.js  src/**/*.test.js  src/**/**/*.test.js ",
+    "test:conversionRate": "LOG_LEVEL=info  NODE_ENV=test mocha -t 10000  test/pre-tests-script.js  src/services/conversionRates/*.test.js ",
+    "test:circleci": "LOG_LEVEL=info NODE_ENV=test mocha -t 10000 --reporter mocha-junit-reporter  test/pre-tests-script.js  src/**/*.test.js  src/**/**/*.test.js ",
     "test:coverage": "nyc -e '.ts' --r html -r lcov -r text npm run test",
     "eslint": "eslint src/. test/.",
     "eslint:fix": "eslint src/. test/. --fix",

--- a/src/services/conversionRates/conversionRates.service.test.js
+++ b/src/services/conversionRates/conversionRates.service.test.js
@@ -36,11 +36,10 @@ function getConversionRatesTestCases() {
     assert.equal(response.statusCode, 200);
     assert.exists(response.body.rates);
     assert.equal(response.body.rates[symbol], 1);
-    assert.exists(response.body.rates['BTC']);
-    assert.notEqual(response.body.rates['BTC'], 1);
-    assert.exists(response.body.rates['USD']);
-    assert.notEqual(response.body.rates['USD'],1);
-
+    assert.exists(response.body.rates.BTC);
+    assert.notEqual(response.body.rates.BTC, 1);
+    assert.exists(response.body.rates.USD);
+    assert.notEqual(response.body.rates.USD, 1);
   });
 
   it('should hourly get successful result', async function() {

--- a/src/services/conversionRates/conversionRates.service.test.js
+++ b/src/services/conversionRates/conversionRates.service.test.js
@@ -28,6 +28,21 @@ function getConversionRatesTestCases() {
     assert.equal(response.body.rates[btcSymbol], 1);
   });
 
+  it('should get result for PAN', async function() {
+    const symbol = 'PAN';
+    const response = await request(baseUrl)
+      .get(relativeUrl)
+      .query({ symbol });
+    assert.equal(response.statusCode, 200);
+    assert.exists(response.body.rates);
+    assert.equal(response.body.rates[symbol], 1);
+    assert.exists(response.body.rates['BTC']);
+    assert.notEqual(response.body.rates['BTC'], 1);
+    assert.exists(response.body.rates['USD']);
+    assert.notEqual(response.body.rates['USD'],1);
+
+  });
+
   it('should hourly get successful result', async function() {
     const usdSymbol = 'USD';
     const hourlyInterval = 'hourly';

--- a/src/services/conversionRates/getConversionRatesService.js
+++ b/src/services/conversionRates/getConversionRatesService.js
@@ -44,7 +44,7 @@ const _getRatesCoinGecko = async (requestedSymbol, timestampMS, coingeckoId, rat
   rates[requestedSymbol] = 1;
 
   const promises = ratesToGet.map(async r => {
-    const symbol = getTokenBySymbol(requestedSymbol).rateEqSymbol || requestedSymbol;
+    const symbol = getTokenBySymbol(r).rateEqSymbol || r;
     if (symbol !== requestedSymbol) {
       rates[r] = await fetchCoingecko(timestampMS, coingeckoId, symbol);
     } else {

--- a/test/pre-tests-script.js
+++ b/test/pre-tests-script.js
@@ -7,16 +7,21 @@ function sleep(ms) {
 before(async () => {
   try {
     // await mongoServer.getUri();
+    console.log('pre-test 0')
+
     await seedData();
+    console.log('test db restored')
 
     // If we require startServer before initializing mongo the server will not responding, I dont know the reason yet
     /* eslint-disable-next-line */
     const { startServer } = require('../src/server');
+    console.log('starting server')
     // we need to wait after setting up of mongoServer we starServer
     await startServer();
-
+    console.log('feathers server is up')
     // This is because it takes seconds to feather server starts
-    await sleep(3000);
+    await sleep(1000);
+    console.log('going to run tests .....')
     // console.log('after running feather js', mongoUri);
   } catch (e) {
     console.log('error in beforeAll', e);

--- a/test/pre-tests-script.js
+++ b/test/pre-tests-script.js
@@ -7,21 +7,19 @@ function sleep(ms) {
 before(async () => {
   try {
     // await mongoServer.getUri();
-    console.log('pre-test 0')
-
     await seedData();
-    console.log('test db restored')
+    console.log('test db restored');
 
     // If we require startServer before initializing mongo the server will not responding, I dont know the reason yet
     /* eslint-disable-next-line */
     const { startServer } = require('../src/server');
-    console.log('starting server')
+    console.log('starting server');
     // we need to wait after setting up of mongoServer we starServer
     await startServer();
-    console.log('feathers server is up')
+    console.log('feathers server is up');
     // This is because it takes seconds to feather server starts
     await sleep(1000);
-    console.log('going to run tests .....')
+    console.log('going to run tests .....');
     // console.log('after running feather js', mongoUri);
   } catch (e) {
     console.log('error in beforeAll', e);

--- a/test/testUtility.js
+++ b/test/testUtility.js
@@ -66,7 +66,7 @@ function getJwt(address = testAddress) {
 
 async function dropDb() {
   return new Promise((resolve, reject) => {
-    console.log('dropping db')
+    console.log('dropping db');
     mongoose.connect(config.get('mongodb'), error => {
       if (error) {
         reject(error);
@@ -79,7 +79,7 @@ async function dropDb() {
 }
 async function seedData() {
   await dropDb();
-  console.log('test db dropped')
+  console.log('test db dropped');
   const dbName = config.get('mongodb').split('/')[config.get('mongodb').split('/').length - 1];
   await restore.database({
     uri: config.get('mongodb').replace(dbName, ''),

--- a/test/testUtility.js
+++ b/test/testUtility.js
@@ -66,6 +66,7 @@ function getJwt(address = testAddress) {
 
 async function dropDb() {
   return new Promise((resolve, reject) => {
+    console.log('dropping db')
     mongoose.connect(config.get('mongodb'), error => {
       if (error) {
         reject(error);
@@ -78,6 +79,7 @@ async function dropDb() {
 }
 async function seedData() {
   await dropDb();
+  console.log('test db dropped')
   const dbName = config.get('mongodb').split('/')[config.get('mongodb').split('/').length - 1];
   await restore.database({
     uri: config.get('mongodb').replace(dbName, ''),


### PR DESCRIPTION
Test case written
related to Giveth/giveth-dapp#1555


For testing this locally add 
```
 {
      "name": "PAN",
      "address": "0xd56dac73a4d6766464b38ec6d91eb45ce7457c44",
      "foreignAddress": "0x0aaf4acccddb40cdb6a1df3cfbc7944aa5effcc6",
      "symbol": "PAN",
      "coingeckoId": "panvala-pan",
      "decimals": 2
    }
```

to `tokenWhitelist` in `config/default.json`
and call this :
```
curl --location --request GET 'http://localhost:3030/conversionRates?symbol=PAN'
```

I get this response for above curl that it seems it's correct:
```
{
    "timestamp": 1610928000000,
    "rates": {
        "PAN": 1,
        "BTC": 0.000002485964716868815,
        "AUD": 0.11575426920095173,
        "CAD": 0.113039047140285,
        "GBP": 0.06547959621174701,
        "ETH": 0.00007229878058344091,
        "BRL": 0.47098825909339,
        "CHF": 0.07932592965698197,
        "USD": 0.08897699766243318,
        "THB": 2.6770073299407575,
        "MXN": 1.7617445537161742,
        "CZK": 1.9288522530259902,
        "EUR": 0.07365951853784762
    }
}
```
(I suggest before testing delete the conversionRates in db to making sure that endpoint doesnt use db cache