### PR TITLE
add slug

### DIFF
--- a/migrations/20210204190556-add-slug-to-projects.js
+++ b/migrations/20210204190556-add-slug-to-projects.js
@@ -1,0 +1,57 @@
+function slugify(title) {
+  return title
+    .replace(/[^a-zA-Z\d\s_()-./\\]/g, '')
+    .replace(/(\s|_|\(|\)|\/|\\|\.)+/g, '-')
+    .toLowerCase();
+}
+module.exports = {
+  async up(db, client) {
+    // add slug to dacs
+    const dacs = await db
+      .collection('dacs')
+      .find({})
+      .toArray();
+    await Promise.all(
+      dacs.map(async dac => {
+        const { title } = dac;
+        const slug = slugify(title);
+        await db.collection('dacs').updateOne({ _id: dac._id }, { $set: { slug } });
+      }),
+    );
+
+    // add slug to campaigns
+    const campaigns = await db
+      .collection('campaigns')
+      .find({})
+      .toArray();
+    await Promise.all(
+      campaigns.map(async campaign => {
+        const { title } = campaign;
+        const slug = slugify(title);
+        await db.collection('campaigns').updateOne({ _id: campaign._id }, { $set: { slug } });
+      }),
+    );
+
+    // add slug to milestones
+    const milestones = await db
+      .collection('milestones')
+      .find({})
+      .toArray();
+    await Promise.all(
+      milestones.map(async milestone => {
+        const { title } = milestone;
+        const slug = slugify(title);
+        await db.collection('milestones').updateOne({ _id: milestone._id }, { $set: { slug } });
+      }),
+    );
+    await db.collection('dacs').createIndex({ slug: 1 }, { unique: true });
+    // await db.collection('campaigns').createIndex({ slug: 1 }, { unique: true });
+    // await db.collection('milestones').createIndex({ slug: 1 }, { unique: true });
+  },
+
+  async down(db, client) {
+    // TODO write the statements to rollback your migration (if possible)
+    // Example:
+    // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
+  },
+};

--- a/src/models/dacs.model.js
+++ b/src/models/dacs.model.js
@@ -21,6 +21,7 @@ function createModel(app) {
     // ipfs enabled
     {
       title: { type: String, required: true },
+      slug: { type: String, required: true },
       description: { type: String, required: true },
       communityUrl: { type: String },
       // FIXME: Should be unique but since we are using 0 for new DACs there can be more than one pending... Should instead be undefined
@@ -53,6 +54,7 @@ function createModel(app) {
   dac.index({ status: 1, createdAt: 1 });
   dac.index({ ownerAddress: 1, createdAt: 1 });
   dac.index({ delegateId: 1, ownerAddress: 1 });
+  dac.index({ slug: 1 }, { unique: true });
   return mongooseClient.model('dac', dac);
 }
 

--- a/src/services/dacs/checkDacSlug.js
+++ b/src/services/dacs/checkDacSlug.js
@@ -1,0 +1,28 @@
+const errors = require('@feathersjs/errors');
+
+/**
+ * This function checks if milestones name is unique in the campaign scope
+ * */
+const checkIfDacSlugIsUnique = () => async context => {
+  const { data, app } = context;
+  if (!data.slug) {
+    return context;
+  }
+  const { slug } = data;
+  const dacService = app.service('dacs');
+  const dacWithSameSlug = await dacService.find({
+    query: {
+      slug,
+    },
+  });
+  if (dacWithSameSlug.total > 0) {
+    // milestone titles are supposed to be unique
+    throw new errors.Forbidden(
+      `A DAC with slug '${slug}' already exists. Please select a different slug.`,
+      { showMessageInPopup: true },
+    );
+  }
+  return context;
+};
+
+module.exports = checkIfDacSlugIsUnique;

--- a/src/services/dacs/dacs.hooks.js
+++ b/src/services/dacs/dacs.hooks.js
@@ -6,6 +6,7 @@ const setAddress = require('../../hooks/setAddress');
 const sanitizeHtml = require('../../hooks/sanitizeHtml');
 const addConfirmations = require('../../hooks/addConfirmations');
 const resolveFiles = require('../../hooks/resolveFiles');
+const checkDacSlug = require('./checkDacSlug');
 
 const restrict = [
   context => commons.deleteByDot(context.data, 'txHash'),
@@ -89,12 +90,14 @@ module.exports = {
       isDacAllowed(),
       sanitizeAddress('ownerAddress', { required: true, validate: true }),
       sanitizeHtml('description'),
+      checkDacSlug(),
     ],
     update: [commons.disallow()],
     patch: [
       ...restrict,
       sanitizeAddress('ownerAddress', { validate: true }),
       sanitizeHtml('description'),
+      checkDacSlug(),
     ],
     remove: [commons.disallow()],
   },


### PR DESCRIPTION
The slug for dacs are ready now. Please test it.
First of all, run migrate-mongo up to create slug for old entities.
@aminlatifi 