### PR TITLE
Reprocess events that stuck Processing for long time

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -166,5 +166,5 @@
   ],
   "dappMailerUrl": "http://127.0.0.1:3050",
   "dappMailerSecret": "xxMv8a13I3YOZSKq9XmX285N0o4m1qHyKjgQWb2g83daGtPI4VmEw7dImu8kvO2ovG4EMC1bvjO906o365BaJBZtArpnxJCoYsCJ",
-  "minimumPayoutUsdValue": 2
+  "minimumPayoutUsdValue": 200
 }


### PR DESCRIPTION
related to #467

I thinks it's not bad to reprocess those events that stuck `Processing`
I tested this too, I donated to a milestone and after the donation baceme `Committed` I deleted the donation and I changed the related `event` status to `Processing` and change `createdAt` time to one hour ago, then the Feathers change the status of `Processing` to `Waiting` and processed the event and created the donation