### PR TITLE
Create conversation for archived milestones even if prevStatus wasnt inProgress

### DIFF
--- a/src/utils/conversationAndEmailHandler.js
+++ b/src/utils/conversationAndEmailHandler.js
@@ -184,7 +184,8 @@ const handleMilestoneConversationAndEmail = () => async context => {
       milestone: result,
       user,
     });
-  } else if (data.status === ARCHIVED && prevStatus === IN_PROGRESS) {
+  } else if (data.status === ARCHIVED && prevStatus !== ARCHIVED) {
+    // Completed and InProgress milestones could become archived
     _createConversation(CONVERSATION_MESSAGE_CONTEXT.ARCHIVED);
   }
 };


### PR DESCRIPTION

related to #1875

previously the `archived` milestone was created when `InProgress` milestone became `Archived` so I changed it when milestone from anything different than the `Archived` became `Archived` we create conversation