### PR TITLE
Pass txHash to updateMilestone params when handling projctUpdated events

### DIFF
--- a/src/blockchain/projects.js
+++ b/src/blockchain/projects.js
@@ -418,7 +418,7 @@ const projects = (app, liquidPledging) => {
     return data[0];
   }
 
-  async function updateMilestone(project, projectId) {
+  async function updateMilestone(project, projectId, txHash) {
     try {
       let milestone = await getMilestoneById(projectId);
       if (!milestone) {
@@ -440,7 +440,7 @@ const projects = (app, liquidPledging) => {
         url: project.url,
       });
 
-      return milestones.patch(milestone._id, mutation);
+      return milestones.patch(milestone._id, mutation, { eventTxHash: txHash });
     } catch (err) {
       logger.error('updateMilestone error ->', err);
     }
@@ -634,13 +634,14 @@ const projects = (app, liquidPledging) => {
       }
 
       const projectId = event.returnValues.idProject;
+      const txHash = event.transactionHash;
 
       const project = await liquidPledging.getPledgeAdmin(projectId);
 
       // we make the assumption that if there is a parentProject, then the
       // project is a milestone, otherwise it is a campaign
       return project.parentProject > 0
-        ? updateMilestone(project, projectId)
+        ? updateMilestone(project, projectId, txHash)
         : updateCampaign(project, projectId);
     },
 

--- a/src/utils/conversationAndEmailHandler.js
+++ b/src/utils/conversationAndEmailHandler.js
@@ -62,9 +62,11 @@ const handleMilestoneConversationAndEmail = () => async context => {
     }
 
     let createdAt;
+    let transactionFrom;
     try {
-      const { timestamp } = await getTransaction(app, eventTxHash, false);
+      const { timestamp, from } = await getTransaction(app, eventTxHash, false);
       createdAt = timestamp;
+      transactionFrom = from;
     } catch (e) {
       createdAt = new Date();
       logger.error(`Error on getting tx ${eventTxHash} info`, e);
@@ -80,7 +82,9 @@ const handleMilestoneConversationAndEmail = () => async context => {
           txHash: eventTxHash,
           createdAt,
         },
-        { performedByAddress },
+        // performedByAddress filled when user calls endpoint so it would be extracted from user's JWT
+        // but when handling events the user doesnt call endpoints so we should use transactionFrom
+        { performedByAddress: performedByAddress || transactionFrom },
       );
       logger.info('created conversation!', res._id);
     } catch (e) {


### PR DESCRIPTION
related to #1875
When milestone updates by eventHandler the `performedByAddress` will not fill so the conversation would not create ( only works if update call with giveth-dapp) so I pass the txHash to updateMilestone params.

See https://github.com/Giveth/feathers-giveth/blob/0d01a3edc4c1664d1e89a342405e1ce890df0460/src/services/milestones/milestones.hooks.js#L269-L276
and
https://github.com/Giveth/feathers-giveth/blob/0d01a3edc4c1664d1e89a342405e1ce890df0460/src/utils/conversationAndEmailHandler.js#L73-L87

so it cause the conversations not have `ownerAddress` and  finally BUG 

![Screen Shot 1400-02-09 at 22 02 37](https://user-images.githubusercontent.com/9850545/116593777-b5e5da80-a936-11eb-9f98-d95e098c13a1.png)


and this error

https://github.com/Giveth/giveth-dapp/issues/1875#issuecomment-828622042