### PR TITLE
Unset pendingAmountRemaining from Waiting, Committed and ToApprove donations

### DIFF
--- a/src/blockchain/pledges.js
+++ b/src/blockchain/pledges.js
@@ -269,7 +269,14 @@ const pledges = (app, liquidPledging) => {
       mined: true,
       token,
     };
-
+    if (
+      mutation.status === DonationStatus.WAITING ||
+      mutation.status === DonationStatus.COMMITTED ||
+      mutation.status === DonationStatus.TO_APPROVE
+    ) {
+      // should unset pendingAmountRemaining when delegation donation is mined
+      mutation.pendingAmountRemaining = undefined;
+    }
     // Propagate comment and actionTakerAddress for donations created by direct donating
     if (
       donations.length === 1 &&


### PR DESCRIPTION
@aminlatifi 
When updating donations there is no logic for unset `pendingAmountRemaining`, so I added but I don't about possible side effects.
for testing this PR you can use a develop dump in your local then execute these queries:
* db.getCollection('events').updateMany({transactionHash:"0x377bfdad348547a357fbe323b68079b5761a34675eae010016e26790d1ead045"}, {$set:{status:"Waiting"}})
* db.getCollection('donations').updateOne({txHash:"0x377bfdad348547a357fbe323b68079b5761a34675eae010016e26790d1ead045", pledgeId:"245"},
{$set:{pendingAmountRemaining:"10000000000000000000", status:"Pending", mined:false}}
)

Then after running feathers you can see the `pendingAmountRemaining` has been removed

related to #432