### PR TITLE
Dont sort by transactionHash when fetching events from db

### DIFF
--- a/src/blockchain/watcher.js
+++ b/src/blockchain/watcher.js
@@ -56,7 +56,7 @@ async function getPendingEvents(eventsService) {
   // all pending events sorted by txHash & logIndex
   const query = {
     status: EventStatus.PENDING,
-    $sort: { blockNumber: 1, transactionIndex: 1, transactionHash: 1, logIndex: 1 },
+    $sort: { blockNumber: 1, transactionIndex: 1, logIndex: 1 },
   };
   return eventsService.find({ paginate: false, query });
 }
@@ -429,7 +429,6 @@ const watcher = app => {
         isHomeEvent: 1,
         blockNumber: 1,
         transactionIndex: 1,
-        transactionHash: 1,
         logIndex: 1,
       },
       $limit: 100,


### PR DESCRIPTION
transactionHash is not incremental so sort by transactionHash doesn't make sense