### PR TITLE
F 543 add authentication for socketio requests

### DIFF
--- a/src/app.hooks.js
+++ b/src/app.hooks.js
@@ -1,16 +1,29 @@
 // Application hooks that run for every service
 const auth = require('@feathersjs/authentication');
 const { discard } = require('feathers-hooks-common');
+const { NotAuthenticated } = require('@feathersjs/errors');
 const logger = require('./hooks/logger');
+const { isRequestInternal } = require('./utils/feathersUtils');
 
 const authenticate = () => context => {
-  // socket connection is already authenticated
-  if (context.params.provider !== 'rest') return context;
+  // No need to authenticate internal calls
+  if (isRequestInternal(context)) return context;
 
-  return auth.hooks.authenticate('jwt')(context);
+  // socket connection is already authenticated, we just check if user has been set on context.params
+  if (context.params.provider === 'socketio' && context.params.user) {
+    return context;
+  }
+  // if the path is authentication that means user wants to login and get accessToken
+  if (context.params.provider === 'socketio' && context.path === 'authentication') {
+    return context;
+  }
+  if (context.params.provider === 'rest') {
+    return auth.hooks.authenticate('jwt')(context);
+  }
+  throw new NotAuthenticated();
 };
 
-const convertVerfiedToBoolean = () => context => {
+const convertVerifiedToBoolean = () => context => {
   // verified field is boolean in Trace, Campaign and Community so for getting this filter
   // in query string we should cast it to boolean here
   if (context.params.query && context.params.query.verified === 'true') {
@@ -24,7 +37,7 @@ const convertVerfiedToBoolean = () => context => {
 module.exports = {
   before: {
     all: [],
-    find: [convertVerfiedToBoolean()],
+    find: [convertVerifiedToBoolean()],
     get: [],
     create: [authenticate()],
     update: [authenticate()],

--- a/src/services/traces/traces.service.test.js
+++ b/src/services/traces/traces.service.test.js
@@ -113,7 +113,7 @@ function postMilestoneTestCases() {
     createMileStoneData.status = SAMPLE_DATA.TRACE_STATUSES.PROPOSED;
     createMileStoneData.ownerAddress = generateRandomEtheriumAddress();
     const trace = await createTrace(createMileStoneData);
-    assert.equal(trace.ownerAddress, SAMPLE_DATA.USER_ADDRESS )
+    assert.equal(trace.ownerAddress, SAMPLE_DATA.USER_ADDRESS);
   });
 }
 

--- a/src/services/traces/traces.service.test.js
+++ b/src/services/traces/traces.service.test.js
@@ -1,7 +1,13 @@
 const request = require('supertest');
 const config = require('config');
 const { assert, expect } = require('chai');
-const { getJwt, SAMPLE_DATA, generateRandomMongoId } = require('../../../test/testUtility');
+const {
+  getJwt,
+  SAMPLE_DATA,
+  generateRandomMongoId,
+  generateRandomEtheriumAddress,
+  assertThrowsAsync,
+} = require('../../../test/testUtility');
 const { getFeatherAppInstance } = require('../../app');
 
 let app;
@@ -101,6 +107,16 @@ function postMilestoneTestCases() {
     createMileStoneData.ownerAddress = SAMPLE_DATA.USER_ADDRESS;
     const trace = await createTrace(createMileStoneData);
     assert.isFalse(trace.verified);
+  });
+
+  it('should throw exception with create trace with ownerAddress of another user', async () => {
+    const createMileStoneData = { ...SAMPLE_DATA.createTraceData(), verified: true };
+    createMileStoneData.status = SAMPLE_DATA.TRACE_STATUSES.PROPOSED;
+    createMileStoneData.ownerAddress = generateRandomEtheriumAddress();
+    const badFunc = async () => {
+      await createTrace(createMileStoneData);
+    };
+    await assertThrowsAsync(badFunc, 'user can create trace with his/her address');
   });
 }
 

--- a/src/services/traces/traces.service.test.js
+++ b/src/services/traces/traces.service.test.js
@@ -6,7 +6,6 @@ const {
   SAMPLE_DATA,
   generateRandomMongoId,
   generateRandomEtheriumAddress,
-  assertThrowsAsync,
 } = require('../../../test/testUtility');
 const { getFeatherAppInstance } = require('../../app');
 
@@ -109,14 +108,12 @@ function postMilestoneTestCases() {
     assert.isFalse(trace.verified);
   });
 
-  it('should throw exception with create trace with ownerAddress of another user', async () => {
+  it('should set userAddress as ownerAddress of trace, doesnt matter what you send', async () => {
     const createMileStoneData = { ...SAMPLE_DATA.createTraceData(), verified: true };
     createMileStoneData.status = SAMPLE_DATA.TRACE_STATUSES.PROPOSED;
     createMileStoneData.ownerAddress = generateRandomEtheriumAddress();
-    const badFunc = async () => {
-      await createTrace(createMileStoneData);
-    };
-    await assertThrowsAsync(badFunc, 'user can create trace with his/her address');
+    const trace = await createTrace(createMileStoneData);
+    assert.equal(trace.ownerAddress, SAMPLE_DATA.USER_ADDRESS )
   });
 }
 


### PR DESCRIPTION
related to #543 

@aminlatifi  As you said we had no authentication for socketio requests, so when you were calling any `create`, `update` requests you would get exception in the service codes but the authentication middleware wasn't stopping you.

* This is the previous code (calling socketio request with postman):

<img width="1004" alt="Screen Shot 1400-04-13 at 22 17 39" src="https://user-images.githubusercontent.com/9850545/124394832-57fab800-dd16-11eb-9dab-ba3e3e5782c3.png">

* This is this code after checking authentication for websocket requests:
<img width="999" alt="Screen Shot 1400-04-13 at 22 24 37" src="https://user-images.githubusercontent.com/9850545/124394890-a4de8e80-dd16-11eb-8afa-46228da7d8bc.png">
