### PR TITLE
Add whitelist ip for rate limit

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -190,7 +190,8 @@
     "createDonationTtlSeconds":3600,
     "createDonationThreshold":300,
     "createAuthenticationTtlSeconds":60,
-    "createAuthenticationThreshold":10
+    "createAuthenticationThreshold":10,
+    "whitelist": []
   },
   "givethIoUrl": "https://serve.giveth.io/graphql",
   "givethIoProjectsReviewerAddress": "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"

--- a/src/utils/rateLimit.js
+++ b/src/utils/rateLimit.js
@@ -33,10 +33,15 @@ const rateLimit = (options = {}) => {
       context.params._populate ||
       config.rateLimit.disable
     ) {
-      // Should not count internal requests
+      // Should not check rate limit
       return context;
     }
     const ip = context.params.headers['x-real-ip'] || context.params.headers.cookie;
+    if (config.rateLimit.whitelist && config.rateLimit.whitelist.includes(ip)) {
+      // Dont count rate limit for whitelist IPs
+      return context;
+    }
+
     // if we just use ip as key, can not use separate rate limit for separate web services
     const key = `${context.path}-${context.method}-${ip}`;
     try {


### PR DESCRIPTION
related to #610

we should Add `whitelist` to `ratelimit` in `config` and add bridge-monitor and our IPs to that array