### PR TITLE
Don't return stack errors to client

### DIFF
--- a/src/app.hooks.js
+++ b/src/app.hooks.js
@@ -69,8 +69,8 @@ const parseErrors = () => context => {
     logger.info('Mongo error in feathers call', context.error);
     throw new errors.BadRequest(errorMessages.INVALID_INPUT_DATA);
   }
-  if (context.error.stack) {
-    // Should not return stack error to client
+  if (context.error.stack && context.error.type !== 'FeathersError') {
+    // Should not return stack error to client when error is not instance of Feathers error
     logger.info('Error with stack', context.error);
     throw new errors.GeneralError();
   }

--- a/src/app.hooks.js
+++ b/src/app.hooks.js
@@ -58,7 +58,7 @@ const convertVerifiedToBoolean = () => context => {
   return context;
 };
 
-const changeMongoErrors = () => context => {
+const parseErrors = () => context => {
   // verified field is boolean in Trace, Campaign and Community so for getting this filter
   // in query string we should cast it to boolean here
   if (context.error.message.includes('Invalid query parameter')) {
@@ -68,6 +68,11 @@ const changeMongoErrors = () => context => {
   if (context.error.stack && context.error.stack.includes('MongoError')) {
     logger.info('Mongo error in feathers call', context.error);
     throw new errors.BadRequest(errorMessages.INVALID_INPUT_DATA);
+  }
+  if (context.error.stack) {
+    // Should not return stack error to client
+    logger.info('Error with stack', context.error);
+    throw new errors.GeneralError();
   }
   return context;
 };
@@ -123,7 +128,7 @@ module.exports = {
   },
 
   error: {
-    all: [responseLoggerHook(), changeMongoErrors()],
+    all: [responseLoggerHook(), parseErrors()],
     find: [],
     get: [],
     create: [],


### PR DESCRIPTION
related to #612

Test with this data in websocket: 
`4221["campaigns::find",{"$or":{"coownerAddress":"0x5AC583Feb2b1f288C0A51d6Cdca2e8c814BFE93B"},"$select":["_id"]}]`

**Before**

<img width="1055" alt="stack error before fix" src="https://user-images.githubusercontent.com/9850545/133244623-f7b342b3-11e4-4ba5-a305-ff0910c7f0a0.png">

**After**
<img width="1056" alt="stack error after fix" src="https://user-images.githubusercontent.com/9850545/133244642-fedce1cd-8d86-44e0-8dbc-80b7832f7f05.png">
